### PR TITLE
Update import path of github_flavored_markdown package.

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/codegangsta/cli"
 	"github.com/go-fsnotify/fsnotify"
 	"github.com/hhatto/gorst"
-	"github.com/shurcooL/go/github_flavored_markdown"
+	"github.com/shurcooL/github_flavored_markdown"
 	"github.com/skratchdot/open-golang/open"
 )
 


### PR DESCRIPTION
It has moved out into a standalone repo recently. See https://github.com/shurcooL/go/issues/19#issuecomment-102574426 for rationale.
